### PR TITLE
Fix resume scaling on large screens

### DIFF
--- a/css/resume.css
+++ b/css/resume.css
@@ -23,6 +23,8 @@ body {
 .container {
     margin: 0 auto;
     background: white;
+    width: 90%;
+    max-width: 1200px;
 }
 
 /* ===================================== */
@@ -75,10 +77,10 @@ body {
 .left-cell, .right-cell {
     background: var(--color-blue);
     color: white;
-    width: 24vw;
+    width: clamp(200px, 24vw, 280px);
     height: 24vh;
     padding: 8vh 0;
-    font-size: 3vw;
+    font-size: clamp(1.5rem, 3vw, 2.5rem);
     font-weight: bold;
     text-align: center;
     margin-right: 60px;
@@ -92,7 +94,7 @@ body {
 }
 
 .content-text {
-    font-size: 1.125vw;
+    font-size: clamp(1rem, 1.125vw, 1.2rem);
     line-height: 1.7;
     color: var(--color-text);
     flex: 1;
@@ -112,7 +114,7 @@ body {
 }
 
 .profile-text {
-    font-size: 1.125vw;
+    font-size: clamp(1rem, 1.125vw, 1.2rem);
     line-height: 1.7;
     color: #333;
     flex: 1;
@@ -136,7 +138,7 @@ body {
 .education-content {
     margin-right: 120px;
     flex: 1;
-    font-size: 5vw;
+    font-size: clamp(2rem, 5vw, 3rem);
 }
 
 /* ===================================== */
@@ -178,7 +180,7 @@ body {
 
 .skill-box .title {
   display: block;
-  font-size: 1vw;
+  font-size: clamp(0.8rem, 1vw, 1.2rem);
   font-weight: 600;
   color: #333;
 }


### PR DESCRIPTION
## Summary
- constrain width of resume container on large screens
- clamp font and element sizes to keep layout readable on wide screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca9dd6c8832ab8f3eaa72fc9c592